### PR TITLE
Use modern KF5 plugin system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(Qt5 5.2 REQUIRED COMPONENTS Quick)
 find_package(KF5 REQUIRED COMPONENTS I18n ConfigWidgets DBusAddons DocTools KIO NewStuff TextEditor TextWidgets KDELibs4Support)
 find_package(Poppler REQUIRED COMPONENTS Qt5)
 
+set(KDE_INSTALL_USE_QT_SYS_PATHS TRUE)
+
 include(KDEInstallDirs)
 include(KDECompilerSettings NO_POLICY_SCOPE)
 include(KDECMakeSettings)

--- a/src/backends/circuitmacros/CMakeLists.txt
+++ b/src/backends/circuitmacros/CMakeLists.txt
@@ -28,5 +28,4 @@ kcoreaddons_desktop_to_json( cirkuit_circuitmacrosbackend circuitmacrosbackend.d
 )
 target_link_libraries( cirkuit_circuitmacrosbackend  KF5::KIOCore cirkuitlibs)
 
-install( FILES circuitmacrosbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)
 install(TARGETS cirkuit_circuitmacrosbackend DESTINATION ${PLUGIN_INSTALL_DIR})

--- a/src/backends/circuitmacros/CMakeLists.txt
+++ b/src/backends/circuitmacros/CMakeLists.txt
@@ -23,6 +23,9 @@ install(FILES circuitmacrosbackend.kcfg DESTINATION ${KCFG_INSTALL_DIR})
 ki18n_wrap_ui(CircuitMacrosBackend_SRCS settings.ui)
 
 add_library(cirkuit_circuitmacrosbackend MODULE ${CircuitMacrosBackend_SRCS} )
+kcoreaddons_desktop_to_json( cirkuit_circuitmacrosbackend circuitmacrosbackend.desktop
+                             SERVICE_TYPES cirkuit_backend.desktop
+)
 target_link_libraries( cirkuit_circuitmacrosbackend  KF5::KIOCore cirkuitlibs)
 
 install( FILES circuitmacrosbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)

--- a/src/backends/gnuplot/CMakeLists.txt
+++ b/src/backends/gnuplot/CMakeLists.txt
@@ -21,6 +21,9 @@ install(FILES gnuplotbackend.kcfg DESTINATION ${KCFG_INSTALL_DIR})
 ki18n_wrap_ui(GnuplotBackend_SRCS settings.ui)
 
 add_library(cirkuit_gnuplotbackend MODULE ${GnuplotBackend_SRCS} )
+kcoreaddons_desktop_to_json( cirkuit_gnuplotbackend gnuplotbackend.desktop
+                             SERVICE_TYPES cirkuit_backend.desktop
+)
 target_link_libraries( cirkuit_gnuplotbackend  KF5::KIOCore cirkuitlibs)
 
 install( FILES gnuplotbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)

--- a/src/backends/gnuplot/CMakeLists.txt
+++ b/src/backends/gnuplot/CMakeLists.txt
@@ -26,5 +26,4 @@ kcoreaddons_desktop_to_json( cirkuit_gnuplotbackend gnuplotbackend.desktop
 )
 target_link_libraries( cirkuit_gnuplotbackend  KF5::KIOCore cirkuitlibs)
 
-install( FILES gnuplotbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)
 install(TARGETS cirkuit_gnuplotbackend DESTINATION ${PLUGIN_INSTALL_DIR})

--- a/src/backends/null/CMakeLists.txt
+++ b/src/backends/null/CMakeLists.txt
@@ -18,5 +18,4 @@ kcoreaddons_desktop_to_json( cirkuit_nullbackend nullbackend.desktop
 )
 target_link_libraries( cirkuit_nullbackend  cirkuitlibs)
 
-install( FILES nullbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)
 install(TARGETS cirkuit_nullbackend DESTINATION ${PLUGIN_INSTALL_DIR})

--- a/src/backends/null/CMakeLists.txt
+++ b/src/backends/null/CMakeLists.txt
@@ -13,6 +13,9 @@ ecm_qt_declare_logging_category(NullBackend_SRCS
                                 CATEGORY_NAME org.kde.cirkuitnullbackend)
 
 add_library(cirkuit_nullbackend MODULE ${NullBackend_SRCS} )
+kcoreaddons_desktop_to_json( cirkuit_nullbackend nullbackend.desktop
+                             SERVICE_TYPES cirkuit_backend.desktop
+)
 target_link_libraries( cirkuit_nullbackend  cirkuitlibs)
 
 install( FILES nullbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)

--- a/src/backends/pstricks/CMakeLists.txt
+++ b/src/backends/pstricks/CMakeLists.txt
@@ -26,5 +26,4 @@ kcoreaddons_desktop_to_json( cirkuit_pstricksbackend pstricksbackend.desktop
 )
 target_link_libraries( cirkuit_pstricksbackend  KF5::KIOCore cirkuitlibs)
 
-install( FILES pstricksbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)
 install(TARGETS cirkuit_pstricksbackend DESTINATION ${PLUGIN_INSTALL_DIR})

--- a/src/backends/pstricks/CMakeLists.txt
+++ b/src/backends/pstricks/CMakeLists.txt
@@ -21,6 +21,9 @@ install(FILES pstricksbackend.kcfg DESTINATION ${KCFG_INSTALL_DIR})
 ki18n_wrap_ui(PstricksBackend_SRCS settings.ui)
 
 add_library(cirkuit_pstricksbackend MODULE ${PstricksBackend_SRCS} )
+kcoreaddons_desktop_to_json( cirkuit_pstricksbackend pstricksbackend.desktop
+                             SERVICE_TYPES cirkuit_backend.desktop
+)
 target_link_libraries( cirkuit_pstricksbackend  KF5::KIOCore cirkuitlibs)
 
 install( FILES pstricksbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)

--- a/src/backends/tikz/CMakeLists.txt
+++ b/src/backends/tikz/CMakeLists.txt
@@ -18,6 +18,9 @@ add_library(cirkuit_tikzbackend
  tikzbackend.cpp
  tikzdocumentsettings.cpp
  tikzgenerator.cpp)
+kcoreaddons_desktop_to_json( cirkuit_tikzbackend tikzbackend.desktop
+                             SERVICE_TYPES cirkuit_backend.desktop
+)
 target_link_libraries( cirkuit_tikzbackend  KF5::KIOCore cirkuitlibs)
 
 install( FILES tikzbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)

--- a/src/backends/tikz/CMakeLists.txt
+++ b/src/backends/tikz/CMakeLists.txt
@@ -23,5 +23,4 @@ kcoreaddons_desktop_to_json( cirkuit_tikzbackend tikzbackend.desktop
 )
 target_link_libraries( cirkuit_tikzbackend  KF5::KIOCore cirkuitlibs)
 
-install( FILES tikzbackend.desktop  DESTINATION ${SERVICES_INSTALL_DIR}/cirkuit)
 install(TARGETS cirkuit_tikzbackend DESTINATION ${PLUGIN_INSTALL_DIR})

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -24,4 +24,4 @@ set_target_properties( cirkuitlibs PROPERTIES VERSION ${GENERIC_LIB_VERSION} SOV
 generate_export_header(cirkuitlibs BASE_NAME CIRKUIT)
 
 install( TARGETS cirkuitlibs  ${INSTALL_TARGETS_DEFAULT_ARGS} )
-install( FILES cirkuit_backend.desktop  DESTINATION ${SERVICETYPES_INSTALL_DIR})
+install( FILES cirkuit_backend.desktop DESTINATION ${KDE_INSTALL_KSERVICETYPES5DIR} )

--- a/src/lib/backend.cpp
+++ b/src/lib/backend.cpp
@@ -28,7 +28,7 @@
 #include <KServiceTypeTrader>
 #include <KService>
 #include <KConfigSkeleton>
-#include <KPluginInfo>
+#include <KPluginMetaData>
 
 class Cirkuit::BackendPrivate {
 public:
@@ -147,7 +147,8 @@ QList<Backend*> Backend::availableBackends()
         QString error;
         KService::Ptr service = *iter;
         
-        KPluginFactory *factory = KPluginLoader(service->library()).factory();
+        KPluginLoader loader(service->library());
+        KPluginFactory *factory = loader.factory();
         if (!factory) {
             qCWarning(CIRKUIT_DEBUG) << "error: " << error;
             continue;    
@@ -159,10 +160,10 @@ QList<Backend*> Backend::availableBackends()
             continue;
         }        
    
-        KPluginInfo info(service);
+        KPluginMetaData info(loader);
         backend->d->name = info.name();
-        backend->d->comment = info.comment();
-        backend->d->icon = info.icon();
+        backend->d->comment = info.description();
+        backend->d->icon = info.iconName();
         backend->d->url = info.website();
         backendCache << backend;
     }

--- a/src/lib/backend.cpp
+++ b/src/lib/backend.cpp
@@ -144,19 +144,18 @@ QList<Backend*> Backend::availableBackends()
     
     KService::List::const_iterator iter;
     for (iter = services.begin(); iter < services.end(); ++iter) {
-        QString error;
         KService::Ptr service = *iter;
         
         KPluginLoader loader(service->library());
         KPluginFactory *factory = loader.factory();
         if (!factory) {
-            qCWarning(CIRKUIT_DEBUG) << "error: " << error;
+            qCWarning(CIRKUIT_DEBUG) << "error: " << loader.errorString();
             continue;    
         }
         
         Backend* backend = factory->create<Backend>(0);
         if (!backend) {
-            qCWarning(CIRKUIT_DEBUG) << "error: " << error;
+            qCWarning(CIRKUIT_DEBUG) << "error: " << loader.errorString();
             continue;
         }        
    

--- a/src/lib/cirkuit_macros.h
+++ b/src/lib/cirkuit_macros.h
@@ -30,7 +30,7 @@
   Exports Backend plugin.
 */
 #define K_EXPORT_CIRKUIT_PLUGIN(libname, classname) \
-    K_PLUGIN_FACTORY(factory, registerPlugin<classname>();) \
+    K_PLUGIN_FACTORY_WITH_JSON(libname, #libname ".json", registerPlugin<classname>();) \
     K_EXPORT_PLUGIN_VERSION(CIRKUIT_VERSION)
 
 #endif /* CIRKUIT_MACROS_H */

--- a/src/lib/cirkuit_macros.h
+++ b/src/lib/cirkuit_macros.h
@@ -31,7 +31,6 @@
 */
 #define K_EXPORT_CIRKUIT_PLUGIN(libname, classname) \
     K_PLUGIN_FACTORY(factory, registerPlugin<classname>();) \
-    K_EXPORT_PLUGIN(factory("cirkuit_" #libname)) \
     K_EXPORT_PLUGIN_VERSION(CIRKUIT_VERSION)
 
 #endif /* CIRKUIT_MACROS_H */


### PR DESCRIPTION
This is a basic approach to use KF5's or Qt5's new plugin system to get rid of some deprecated KDE4 members.
## Changes so far
- embed desktop files as json metadata inside plugin
- use `KPluginLoader::findPlugins()` instead of the _old_ `KService` & `KSycoca` mechanism
- removed use of deprecated class `KPluginInfo`
- removed use of deprecated macro `K_EXPORT_PLUGIN`
## Todo

The following things could be done to further improve the code:
1. convert desktop files permanently to the new json format
   - cirkuit_backend.desktop could be dropped
2. use `kcoreaddons_add_plugin()` instead of separate `add_library()` and `install()` commands in the CMakeLists.txt files
   - build system will then also depend on json-file and trigger a build update if the metadata is changed
   - simplify CMakeLists.txt
3. move plugins to subdir inside of Qt5's plugin dir
   - `KPluginLoader::findPlugins()` will not have to scan _all_ plugins
